### PR TITLE
No need to wait everything before we can startup.

### DIFF
--- a/rpm/udhcpd.service
+++ b/rpm/udhcpd.service
@@ -1,4 +1,8 @@
 [Unit]
 Description=udhcpcd DHCP server
+DefaultDependencies=no
+After=local-fs.target
+Conflicts=shutdown.target
+
 [Service]
 ExecStart=/usr/sbin/udhcpd -f


### PR DESCRIPTION
[udhcpd] Let udhcpd.service be started earlier.

No need to wait for default dependencies as only thing we need currently
is the /etc/udhcpd.conf file which is available after local-fs.target
and created by the process who starts this service if not existing
before.

Signed-off-by: Marko Saukko <marko.saukko@jolla.com>